### PR TITLE
Accept random_compat v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"docs": "https://www.paydirekt.de/haendler/merchant-api.html"
 	},
 	"require": {
-		"paragonie/random_compat": "^1.2",
+		"paragonie/random_compat": "^1.2||^2.0.11",
 		"php": ">=5.5",
 		"lib-curl": "*"
 	},


### PR DESCRIPTION
This change improves compatibility with many other PHP packages which depend on `paragonie/random_compat` v2 and are therefore incompatible with this paydirekt library.

The change works because random_compat v2 serves only to officially remove the OpenSSL fallback
which was already removed once in random_compat v1.3.0.
Indeed the paydirekt library does not need this fallback as long as `/dev/urandom` or the `mcrypt` extension is available (or if it runs on PHP 7 in which case the entire random_compat library goes unused).

As this change still allows the older version constraint (`^v1.2`), it does not break backwards compatiblity for existing installations.

All unit tests still pass with this change both in a PHP 7.2.2 and PHP 5.5.9 Linux environment.
